### PR TITLE
Add simple Gin server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # playground
+
+This repository provides a minimal [Gin](https://github.com/gin-gonic/gin) example.
+
+## Running
+
+Run the server with:
+
+```
+go run main.go
+```
+
+The server listens on port `8080` and responds with `{"message":"Hello, World!"}` at the root path.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module playground
+
+go 1.24.3

--- a/main.go
+++ b/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+	r.GET("/", func(c *gin.Context) {
+		c.JSON(200, gin.H{"message": "Hello, World!"})
+	})
+	r.Run()
+}


### PR DESCRIPTION
## Summary
- initialize Go module
- add a small Gin server
- document usage

## Testing
- `go mod tidy` *(fails: module github.com/gin-gonic/gin needs network access)*
- `go build` *(fails: missing github.com/gin-gonic/gin)*


------
https://chatgpt.com/codex/tasks/task_e_684ccf1f298483218b43f34f33ac3310